### PR TITLE
Feature/read airmeta params

### DIFF
--- a/airstack-modules/README.md
+++ b/airstack-modules/README.md
@@ -175,5 +175,6 @@ airstack.nft.trackNFTSaleTransactions(
 If you want to build the module yourself, please follow there steps.
 
 1. Clone the repo
-2. Run the command
+2. Run command`npx @airstack/subgraph-generator <vertical> --name <subgraph_name> --slug <subgraph_slug> --version <subgraph_version>`
+3. Run the command
    `npm run build`

--- a/airstack-modules/bin/index.ts
+++ b/airstack-modules/bin/index.ts
@@ -2,7 +2,7 @@
 
 import { Vertical } from "../src/constants";
 import { integrate } from "../src/integrate";
-
+import { AirMetatypes } from "../src/types"
 const args = process.argv.slice(2);
 
 if (args.length == 0) {
@@ -11,6 +11,21 @@ if (args.length == 0) {
 }
 
 const vertical: string = args[0];
+let params: AirMetatypes = {
+  name: "",
+  version: "",
+  slug: "",
+}
+
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === "--name") {
+    params.name = args[i + 1]
+  } else if (args[i] === "--version") {
+    params.version = args[i + 1]
+  } else if (args[i] === "--slug") {
+    params.slug = args[i + 1]
+  }
+}
 let graphql: string = "./schema.graphql";
 let yaml: string = "./subgraph.yaml";
 let dataSources: Array<string> | undefined = undefined;
@@ -66,7 +81,7 @@ for (let index = START_INDEX; index < args.length; index++) {
   }
 }
 
-integrate(vertical, yaml, graphql, dataSources, templates)
+integrate(vertical,params, yaml, graphql, dataSources, templates)
   .then(() => {
     switch (vertical) {
 

--- a/airstack-modules/src/integrate.ts
+++ b/airstack-modules/src/integrate.ts
@@ -5,10 +5,12 @@ import * as yaml from "js-yaml";
 import fse from "fs-extra";
 import path from "path";
 import mustache from "mustache";
+import {AirMetatypes}from "./types"
 var readlineSync = require('readline-sync');
 
 export async function integrate(
   vertical: string,
+  params: AirMetatypes,
   yamlPath: string,
   graphql: string,
   dataSources?: Array<string>,
@@ -35,7 +37,7 @@ export async function integrate(
         writeSubgraphGraphql(vertical as Vertical, graphql)
           .then(() => {
             const { targetDir, commontTargetDir } = copyAirstackModules(vertical as Vertical);
-            getAirMetaDetails(vertical as Vertical);
+            getAirMetaDetails(params)
             const arrayOfFiles: Array<string> = []
             const arrayOfCommonFiles: Array<string> = []
             getAllFiles(targetDir, arrayOfFiles)
@@ -298,28 +300,13 @@ function getAllFiles(dirPath: string, arrayOfFiles: Array<string>) {
   return arrayOfFiles
 }
 
-export var SUBGRAPH_NAME = "";
-export var SUBGRAPH_VERSION = "";
-export var SUBGRAPH_SLUG = "";
 
-function getAirMetaDetails(vertical: Vertical) {
-  while (SUBGRAPH_NAME.trim() === "") {
-    let subgraphName: string = readlineSync.question("Enter the name of the subgraph: ");
-    SUBGRAPH_NAME = subgraphName;
-  }
-  while (SUBGRAPH_VERSION.trim() === "") {
-    let subgraphVersion: string = readlineSync.question("Enter the version of the subgraph: ");
-    SUBGRAPH_VERSION = subgraphVersion;
-  }
-  while (SUBGRAPH_SLUG.trim() === "") {
-    let subgraphSlug: string = readlineSync.question("Enter the slug of the subgraph: ");
-    SUBGRAPH_SLUG = subgraphSlug;
-  }
+function getAirMetaDetails(params:AirMetatypes) {
   let targetFile = path.resolve(__dirname, '../../../../../modules/airstack/common/index.ts');
   let fileContent = fs.readFileSync(targetFile, { encoding: "utf8" });
-  fileContent = fileContent.replace(/export const SUBGRAPH_NAME = ".*";/g, `export const SUBGRAPH_NAME = "${SUBGRAPH_NAME}";`);
-  fileContent = fileContent.replace(/export const SUBGRAPH_VERSION = ".*";/g, `export const SUBGRAPH_VERSION = "${SUBGRAPH_VERSION}";`);
-  fileContent = fileContent.replace(/export const SUBGRAPH_SLUG = ".*";/g, `export const SUBGRAPH_SLUG = "${SUBGRAPH_SLUG}";`);
+  fileContent = fileContent.replace(/export const SUBGRAPH_NAME = ".*";/g, `export const SUBGRAPH_NAME = "${params.name}";`);
+  fileContent = fileContent.replace(/export const SUBGRAPH_VERSION = ".*";/g, `export const SUBGRAPH_VERSION = "${params.version}";`);
+  fileContent = fileContent.replace(/export const SUBGRAPH_SLUG = ".*";/g, `export const SUBGRAPH_SLUG = "${params.slug}";`);
   // fileContent += `\nexport const SUBGRAPH_NAME = "${SUBGRAPH_NAME}";\nexport const SUBGRAPH_VERSION = "${SUBGRAPH_VERSION}";\nexport const SUBGRAPH_SLUG = "${SUBGRAPH_SLUG}";\n`
   fs.writeFileSync(targetFile, fileContent, { encoding: "utf8" });
 }

--- a/airstack-modules/src/types.ts
+++ b/airstack-modules/src/types.ts
@@ -1,0 +1,5 @@
+export type AirMetatypes = {
+  name: string
+  version: string
+  slug: string
+}


### PR DESCRIPTION
allows us to pass airmeta variables like `npx @airstack/subgraph-generator <vertical> --name <subgraph_name> --slug <subgraph_slug> --version <subgraph_version>`